### PR TITLE
Fix the gevent timer leak

### DIFF
--- a/nucleon/amqp/connection.py
+++ b/nucleon/amqp/connection.py
@@ -249,14 +249,15 @@ class BaseConnection(object):
                 else:
                     t = None
 
-                frame_header = reader.read(FRAME_HEADER.size)
-                frame_type, channel, size = \
-                    FRAME_HEADER.unpack(frame_header)
+                try:
+                    frame_header = reader.read(FRAME_HEADER.size)
+                    frame_type, channel, size = \
+                        FRAME_HEADER.unpack(frame_header)
 
-                payload = reader.read(size + 1)
-
-                if t is not None:
-                    t.cancel()
+                    payload = reader.read(size + 1)
+                finally:
+                    if t is not None:
+                        t.cancel()
 
                 if payload[-1] != '\xCE':
                     raise ConnectionError('Received invalid frame data')


### PR DESCRIPTION
This is to try and calm down the:
<timer at 0x7f7aacb24320 callback=<bound method Greenlet.throw of <Greenlet at 0x7f7aac9d30f0>> args=(ConnectionError('Heartbeat timeout',),)> failed with ConnectionError
Traceback (most recent call last):
  File "/var/www/env/local/lib/python2.7/site-packages/gevent/greenlet.py", line 166, in throw
    greenlet.throw(self, *args)
ConnectionError: Heartbeat timeout

in the logs, which I think is due to some scenario that's leaking the timers and leaving them uncanceled.
